### PR TITLE
Mark project description as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.1.0 (Unreleased)
+## 0.2.2 (Unreleased)
+
+NOTES:
+
+- resource/project: The `description` field has been deprecated and will be removed in the next major release
 
 ## 0.2.1 (Dec 20, 2021)
 
@@ -12,3 +16,4 @@ FEATURES:
 
 - Initial release
 
+## 0.1.0 (Unreleased)

--- a/internal/gqlclient/models.go
+++ b/internal/gqlclient/models.go
@@ -1,6 +1,5 @@
 package gqlclient
 
-// Project -
 type Project struct {
 	Slug                      string `json:"slug"`
 	Name                      string `json:"name"`

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -34,6 +34,7 @@ func resourceProject() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
+				Deprecated: "Project description will be removed",
 			},
 			"issue_tracker_provider_type": {
 				Description: "Where to find issues linked to by changes",

--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ func main() {
 	opts := &plugin.ServeOpts{ProviderFunc: provider.New(version)}
 
 	if debugMode {
-		// TODO: update this string with the full name of your provider as used in your configs
 		err := plugin.Debug(context.Background(), "registry.terraform.io/sleuth-io/sleuth", opts)
 		if err != nil {
 			log.Fatal(err.Error())


### PR DESCRIPTION
Project description serves no purpose anymore, we have removed it from the web application. Marking as deprecated in the provider in order to enable removal of the field in the next major release.