### PR TITLE
Document valid deployment tracking type options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.15
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg

--- a/docs/resources/code_change_source.md
+++ b/docs/resources/code_change_source.md
@@ -40,7 +40,7 @@ resource "sleuth_code_change_source" "sleuth-terraform-provider" {
 
 ### Required
 
-- `deploy_tracking_type` (String) How to track deploys
+- `deploy_tracking_type` (String) How to track deploys. Valid choices are build, manual, auto_pr, auto_tag, auto_push
 - `environment_mappings` (Block List, Min: 1) (see [below for nested schema](#nestedblock--environment_mappings))
 - `name` (String) Change source name
 - `project_slug` (String) The project for this environment

--- a/internal/provider/resource_code_change_source.go
+++ b/internal/provider/resource_code_change_source.go
@@ -79,7 +79,7 @@ func resourceCodeChangeSource() *schema.Resource {
 				},
 			},
 			"deploy_tracking_type": {
-				Description: "How to track deploys",
+				Description: "How to track deploys. Valid choices are build, manual, auto_pr, auto_tag, auto_push",
 				Type:        schema.TypeString,
 				Required:    true,
 			},


### PR DESCRIPTION
This is the information that users can get from inspecting the [GraphQL schema](https://app.sleuth.io/graphql) `DeployTrackingType`, but it's nicer to have that clearly documented in the provider docs themselves.