### PR TITLE
SD-7531: Update code change source client to include `matchBranchToEnvironment`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ provider "sleuth" {
 The Sleuth provider authenticates to Sleuth using your Sleuth organization API key. Find this by clicking on your
 organization name at the top left, selecting "Organization settings", and looking under "Api key".
 
+You can provide the API key via `SLEUTH_API_KEY` environment variable.
 
 ## Slugs
 

--- a/internal/gqlclient/models.go
+++ b/internal/gqlclient/models.go
@@ -158,21 +158,23 @@ type DeleteImpactSourceMutationInput struct {
 }
 
 type BuildMapping struct {
-	EnvironmentSlug string `json:"environmentSlug"`
-	Provider        string `json:"provider"`
-	BuildName       string `json:"buildName"`
-	JobName         string `json:"jobName,omitempty"`
-	BuildProjectKey string `json:"buildProjectKey,omitempty"`
-	IntegrationSlug string `json:"integrationSlug"`
-	BuildBranch     string `json:"buildBranch"`
+	EnvironmentSlug          string `json:"environmentSlug"`
+	Provider                 string `json:"provider"`
+	BuildName                string `json:"buildName"`
+	JobName                  string `json:"jobName,omitempty"`
+	BuildProjectKey          string `json:"buildProjectKey,omitempty"`
+	IntegrationSlug          string `json:"integrationSlug"`
+	BuildBranch              string `json:"buildBranch"`
+	MatchBranchToEnvironment bool   `json:"matchBranchToEnvironment"`
 }
 
 type DeployTrackingBuildMapping struct {
-	Environment     Environment `json:"environment"`
-	Provider        string      `json:"provider"`
-	BuildName       string      `json:"buildName"`
-	JobName         string      `json:"jobName,omitempty"`
-	BuildProjectKey string      `json:"buildProjectKey"`
+	Environment              Environment `json:"environment"`
+	Provider                 string      `json:"provider"`
+	BuildName                string      `json:"buildName"`
+	JobName                  string      `json:"jobName,omitempty"`
+	BuildProjectKey          string      `json:"buildProjectKey"`
+	MatchBranchToEnvironment bool        `json:"matchBranchToEnvironment"`
 }
 
 type MutableCodeChangeSource struct {

--- a/internal/gqlclient/models.go
+++ b/internal/gqlclient/models.go
@@ -165,7 +165,7 @@ type BuildMapping struct {
 	BuildProjectKey          string `json:"buildProjectKey,omitempty"`
 	IntegrationSlug          string `json:"integrationSlug"`
 	BuildBranch              string `json:"buildBranch"`
-	MatchBranchToEnvironment bool   `json:"matchBranchToEnvironment"`
+	MatchBranchToEnvironment bool   `json:"matchBranchToEnvironment,omitempty"`
 }
 
 type DeployTrackingBuildMapping struct {

--- a/internal/provider/resource_code_change_source.go
+++ b/internal/provider/resource_code_change_source.go
@@ -247,6 +247,7 @@ func setCodeChangeSourceFields(d *schema.ResourceData, projectSlug string, sourc
 		m["job_name"] = v.JobName
 		m["provider"] = v.Provider
 		m["project_key"] = v.BuildProjectKey
+		m["match_branch_to_environment"] = v.MatchBranchToEnvironment
 		m["environment_slug"] = v.Environment
 		buildMappings[idx] = m
 	}
@@ -295,12 +296,13 @@ func populateCodeChangeSource(d *schema.ResourceData, input *gqlclient.MutableCo
 			}
 			if envRaw == envSlug {
 				mapping := gqlclient.BuildMapping{EnvironmentSlug: envSlug,
-					BuildName:       m["build_name"].(string),
-					JobName:         m["job_name"].(string),
-					Provider:        m["provider"].(string),
-					BuildProjectKey: m["project_key"].(string),
-					IntegrationSlug: strings.ToLower(m["provider"].(string)),
-					BuildBranch:     v2.Branch,
+					BuildName:                m["build_name"].(string),
+					JobName:                  m["job_name"].(string),
+					Provider:                 m["provider"].(string),
+					BuildProjectKey:          m["project_key"].(string),
+					MatchBranchToEnvironment: m["match_branch_to_environment"].(bool),
+					IntegrationSlug:          strings.ToLower(m["provider"].(string)),
+					BuildBranch:              v2.Branch,
 				}
 				buildMappings[idx] = mapping
 				break


### PR DESCRIPTION
Warning: I didn't run this except for `make build`. I believe this should correctly add support for given field as described in Linear issue.

I don't know what else has to be done here – will merge to `main` auto release new version or one has to do so manually with `make release`?

Best reviewed with [hidden white space in diff](https://github.com/sleuth-io/terraform-provider-sleuth/pull/66/files?diff=unified&w=1).