### PR TITLE
BROC-305: Update documentation at source to correctly autogenerate it

### DIFF
--- a/examples/resources/sleuth_code_change_source/resource.tf
+++ b/examples/resources/sleuth_code_change_source/resource.tf
@@ -17,4 +17,8 @@ resource "sleuth_code_change_source" "sleuth-terraform-provider" {
   }
   deploy_tracking_type = "manual"
   collect_impact = true
+  path_prefix = jsonencode({
+    excludes = [""]
+    includes = [""]
+  })
 }

--- a/internal/provider/resource_code_change_source.go
+++ b/internal/provider/resource_code_change_source.go
@@ -137,7 +137,7 @@ func resourceCodeChangeSource() *schema.Resource {
 				Default:     true,
 			},
 			"path_prefix": {
-				Description: "What code source path to limit this deployment to. Useful for monorepos",
+				Description: "What code source path to limit this deployment to. Useful for monorepos. Must be used with the [jsonencode()](https://developer.hashicorp.com/terraform/language/functions/jsonencode) function to specify the paths to include and/or exclude respectively. (see example above)",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",

--- a/templates/contributing/README.md.tmpl
+++ b/templates/contributing/README.md.tmpl
@@ -1,8 +1,11 @@
 # Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](../../README.md)).
+The easiest way to do this is to use devbox and run `devbox shell`.
 
 To compile the provider, run `make install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+
+*Note:* if you're on macOS, change `OS_ARCH` in `Makefile` to `darwin_amd64` (Intel) or `darwin_arm64` (Apple silicon)
 
 To generate or update documentation, run `make docs`.
 
@@ -13,6 +16,15 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 ```sh
 $ make testacc
 ```
+
+To run against a local instance of Sleuth, do the following:
+1. Start Sleuth locally so that it is available on http://dev.sleuth.io
+2. Copy the `main.tf.example` file as `main.tf` and edit the file to change `api_key`
+3. Run terraform via `make dev`. Note this will delete the state each time.
+
+# Debugging
+
+You can use `fmt.Print("here")` with combination of `TF_LOG=WARN` env variable when running `terraform plan` or `terraform apply`.
 
 # Adding Dependencies
 


### PR DESCRIPTION
Documentation is autogenerated and for a few updates, we have added it directly into the resulting files. This causes issues when we try to autogenerate docs again causing us to loose already written docs. This PR adds losing data in correct places so autogenerating works again.