### PR TITLE
BROC-205: environment slug always showing as updating in tf plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.11 (unreleased)
+
+FIXES:
+
+- [PR 83](https://github.com/sleuth-io/terraform-provider-sleuth/pull/83) Environment slug should not show up as updating when re-applying
+
+
 ## 0.3.10 (May 19, 2023)
 
 ENHANCEMENTS:

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,8 +1,11 @@
 # Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](../../README.md)).
+The easiest way to do this is to use devbox and run `devbox shell`.
 
 To compile the provider, run `make install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+
+*Note:* if you're on macOS, change `OS_ARCH` in `Makefile` to `darwin_amd64` (Intel) or `darwin_arm64` (Apple silicon)
 
 To generate or update documentation, run `make docs`.
 
@@ -13,6 +16,15 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 ```sh
 $ make testacc
 ```
+
+To run against a local instance of Sleuth, do the following:
+1. Start Sleuth locally so that it is available on http://dev.sleuth.io
+2. Copy the `main.tf.example` file as `main.tf` and edit the file to change `api_key`
+3. Run terraform via `make dev`. Note this will delete the state each time.
+
+# Debugging
+
+You can use `fmt.Print("here")` with combination of `TF_LOG=WARN` env variable when running `terraform plan` or `terraform apply`.
 
 # Adding Dependencies
 

--- a/docs/resources/code_change_source.md
+++ b/docs/resources/code_change_source.md
@@ -45,7 +45,7 @@ resource "sleuth_code_change_source" "sleuth-terraform-provider" {
 ### Required
 
 - `deploy_tracking_type` (String) How to track deploys. Valid choices are build, manual, auto_pr, auto_tag, auto_push
-- `environment_mappings` (Block List, Min: 1) (see [below for nested schema](#nestedblock--environment_mappings))
+- `environment_mappings` (Block List, Min: 1) Environment mappings of the environment. They must be ordered by environment_slug ascending to avoid Terraform plan changes. (see [below for nested schema](#nestedblock--environment_mappings))
 - `name` (String) Change source name
 - `project_slug` (String) The project for this environment
 - `repository` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--repository))
@@ -70,6 +70,10 @@ Required:
 
 - `branch` (String) The repository branch name for the environment
 - `environment_slug` (String) The environment slug or id
+
+Read-Only:
+
+- `id` (String) Computed ID
 
 
 <a id="nestedblock--repository"></a>


### PR DESCRIPTION
We were updating env slugs on the fly - this causes issues when terraform tries to re-calcualate the plan for change.
There is no clear or nice way to remove the plan because SDK calls DiffSuppressFunc on individual values not on whole plan as one.

Current resolution is to introduce id field that is composed of our calculated slug and leave slug as-is to avoid un-necessary changes.

To test:
- Go to master & install provider
- apply `sleuth_code_change_source` with `environment_mapping`
- after successful apply - try to plan/apply again - see changes in `env_mapping`
- switch to this branch and install provider
- try to plan/apply - observe no changes in `env_mapping`

Resolves: https://github.com/sleuth-io/terraform-provider-sleuth/issues/58

