### PR TITLE
BROC-488: Add Blameless as provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ENHANCEMENTS:
 
 - [#107](https://github.com/sleuth-io/terraform-provider-sleuth/pull/107) Update api key documentation 
+- [#109](https://github.com/sleuth-io/terraform-provider-sleuth/pull/109) Add Blameless as Incident Impact Source
 
 ## 0.4.1 (July 25, 2023)
 

--- a/docs/resources/incident_impact_source.md
+++ b/docs/resources/incident_impact_source.md
@@ -60,6 +60,7 @@ resource "sleuth_incident_impact_source" "jira" {
 
 ### Optional
 
+- `blameless_input` (Block List, Max: 1) Blameless input (see [below for nested schema](#nestedblock--blameless_input))
 - `datadog_input` (Block List, Max: 1) DataDog input (see [below for nested schema](#nestedblock--datadog_input))
 - `jira_input` (Block List, Max: 1) JIRA input (see [below for nested schema](#nestedblock--jira_input))
 - `pagerduty_input` (Block List, Max: 1) PagerDuty input (see [below for nested schema](#nestedblock--pagerduty_input))
@@ -69,6 +70,16 @@ resource "sleuth_incident_impact_source" "jira" {
 - `id` (String) The ID of this resource.
 - `register_impact_link` (String) Impact source webhook registration link (for CUSTOM_INCIDENT only)
 - `slug` (String) Impact source slug
+
+<a id="nestedblock--blameless_input"></a>
+### Nested Schema for `blameless_input`
+
+Optional:
+
+- `integration_slug` (String) Blameless IntegrationAuthentication slug from app
+- `remote_severity_threshold` (String) Incidents with matching or lower severities will be considered a failure in Sleuth
+- `remote_types` (Set of String) The types of incidents to the monitors should track
+
 
 <a id="nestedblock--datadog_input"></a>
 ### Nested Schema for `datadog_input`

--- a/examples/resources/sleuth_incident_impact_source/resource.tf
+++ b/examples/resources/sleuth_incident_impact_source/resource.tf
@@ -32,3 +32,15 @@ resource "sleuth_incident_impact_source" "jira" {
     }
 }
 
+resource "sleuth_incident_impact_source" "blameless" {
+    project_slug = "project_slug"
+    name = "Blameless TF incident impact"
+    environment_name = "environment_name"
+    provider_name = "BLAMELESS"
+    blameless_input {
+        remote_types = ["type1", "type2"]
+	remote_severity_threshold = "SEV1"
+        integration_slug = "optional_integration_slug"
+    }
+}
+

--- a/internal/gqlclient/models.go
+++ b/internal/gqlclient/models.go
@@ -235,10 +235,16 @@ type JiraProviderData struct {
 	RemoteJql string `json:"remoteJql"`
 }
 
+type BlamelessProviderData struct {
+	RemoteTypes             []string `json:"remoteTypes"`
+	RemoteSeverityThreshold string   `json:"remoteSeverityThreshold"`
+}
+
 type ProviderData struct {
 	PagerDutyProviderData PagerDutyProviderData `json:"pagerDutyProviderData" graphql:"... on PagerDutyProviderData"`
 	DataDogProviderData   DataDogProviderData   `json:"dataDogProviderData" graphql:"... on DataDogProviderData"`
 	JiraProviderData      JiraProviderData      `json:"jiraProviderData" graphql:"... on JiraProviderData"`
+	BlamelessProviderData BlamelessProviderData `json:"blamelessProviderData" graphql:"... on BlamelessProviderData"`
 }
 
 type IncidentImpactSource struct {
@@ -266,6 +272,11 @@ type JiraInputType struct {
 	IntegrationSlug string `json:"integrationSlug"`
 }
 
+type BlamelessInputType struct {
+	BlamelessProviderData
+	IntegrationSlug string `json:"integrationSlug"`
+}
+
 type IncidentImpactSourceInputType struct {
 	ProjectSlug        string              `json:"projectSlug"`
 	EnvironmentName    string              `json:"environmentName"`
@@ -274,6 +285,7 @@ type IncidentImpactSourceInputType struct {
 	PagerDutyInputType *PagerDutyInputType `json:"pagerDutyInput"`
 	DataDogInputType   *DataDogInputType   `json:"datadogInput"`
 	JiraInputType      *JiraInputType      `json:"jiraInput"`
+	BlamelessInputType *BlamelessInputType `json:"blamelessInput"`
 }
 
 type IncidentImpactSourceInputUpdateType struct {


### PR DESCRIPTION
We have an incident impact source resource, but Blameless is not currently a supported provider. This commit will add Blameless as a supported provider.