### PR TITLE
BROC-495: Update UA for terraform network calls

### DIFF
--- a/internal/gqlclient/client.go
+++ b/internal/gqlclient/client.go
@@ -2,14 +2,15 @@ package gqlclient
 
 import (
 	"context"
-
 	// 	"encoding/json"
 	"fmt"
-	"github.com/shurcooL/graphql"
 	"io/ioutil"
 	"net/http"
+
 	// 	"strings"
 	"time"
+
+	"github.com/shurcooL/graphql"
 )
 
 // Client -
@@ -24,18 +25,19 @@ type Client struct {
 type AuthenticatedTransport struct {
 	T      http.RoundTripper
 	ApiKey string
+	UA     string
 }
 
 func (transport *AuthenticatedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add("User-Agent", "sleuth-terraform")
+	req.Header.Add("User-Agent", transport.UA)
 	req.Header.Add("Authorization", fmt.Sprintf("apikey %s", transport.ApiKey))
 	return transport.T.RoundTrip(req)
 }
 
 // NewClient -
-func NewClient(baseurl, apiKey *string) (*Client, error) {
+func NewClient(baseurl, apiKey *string, ua string) (*Client, error) {
 	httpClient := http.Client{Timeout: 20 * time.Second,
-		Transport: &AuthenticatedTransport{http.DefaultTransport, *apiKey}}
+		Transport: &AuthenticatedTransport{http.DefaultTransport, *apiKey, ua}}
 	c := Client{
 		GQLClient:  graphql.NewClient(*baseurl+"/graphql", &httpClient),
 		HTTPClient: &httpClient,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,8 +2,10 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/sleuth-io/terraform-provider-sleuth/internal/gqlclient"
 )
 
@@ -62,6 +64,7 @@ func New(version string) func() *schema.Provider {
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+
 		apiKey := d.Get("api_key").(string)
 
 		var baseurl *string
@@ -75,7 +78,8 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		// Warning or errors can be collected in a slice type
 		var diags diag.Diagnostics
 
-		c, err := gqlclient.NewClient(baseurl, &apiKey)
+		ua := p.UserAgent("sleuth_terraform_provider", version)
+		c, err := gqlclient.NewClient(baseurl, &apiKey, ua)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,


### PR DESCRIPTION
Update our user agent to provide Terraform & sleuth-terraform-provider version by using `UserAgent` method