### PR TITLE
BROC-262: Rewrite environment resource using Framework SDK

### DIFF
--- a/internal/gqlclient/environments.go
+++ b/internal/gqlclient/environments.go
@@ -2,8 +2,12 @@ package gqlclient
 
 import (
 	"errors"
+	"fmt"
+
 	"github.com/shurcooL/graphql"
 )
+
+var ErrNotFound = errors.New("Resource was not found")
 
 func (c *Client) GetEnvironmentByName(projectSlug *string, name *string) (*Environment, error) {
 	var query struct {
@@ -26,7 +30,7 @@ func (c *Client) GetEnvironmentByName(projectSlug *string, name *string) (*Envir
 			return &env, nil
 		}
 	}
-	return nil, errors.New("Not found")
+	return nil, ErrNotFound
 }
 
 // GetEnvironment - Returns environment
@@ -74,7 +78,7 @@ func (c *Client) CreateEnvironment(input CreateEnvironmentMutationInput) (*Envir
 	}
 
 	if len(m.CreateEnvironment.Errors) > 0 {
-		return nil, errors.New("Errors creating environment")
+		return nil, fmt.Errorf("errors creating environment: %+v", m.CreateEnvironment.Errors)
 	}
 	return &m.CreateEnvironment.Environment, nil
 }
@@ -111,6 +115,7 @@ func (c *Client) DeleteEnvironment(projectSlug *string, slug *string) error {
 	var m struct {
 		DeleteEnvironment struct {
 			Success graphql.Boolean
+			Errors  ErrorsType
 		} `graphql:"deleteEnvironment(input: $input)"`
 	}
 	variables := map[string]interface{}{
@@ -124,7 +129,7 @@ func (c *Client) DeleteEnvironment(projectSlug *string, slug *string) error {
 	}
 
 	if !m.DeleteEnvironment.Success {
-		return errors.New("Missing")
+		return fmt.Errorf("deleting environment was not successful: %+v", m.DeleteEnvironment.Errors)
 	} else {
 		return nil
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -48,7 +48,7 @@ func New(version string) func() *schema.Provider {
 			//},
 			ResourcesMap: map[string]*schema.Resource{
 				//"sleuth_project":                resourceProject(),
-				"sleuth_environment":          resourceEnvironment(),
+				//"sleuth_environment":          resourceEnvironment(),
 				"sleuth_error_impact_source":  resourceErrorImpactSource(),
 				"sleuth_metric_impact_source": resourceMetricImpactSource(),
 				//"sleuth_code_change_source":     resourceCodeChangeSource(),

--- a/internal/sleuth/environment_resource.go
+++ b/internal/sleuth/environment_resource.go
@@ -1,0 +1,253 @@
+package sleuth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/sleuth-io/terraform-provider-sleuth/internal/gqlclient"
+)
+
+var (
+	_ resource.Resource                = &environmentResource{}
+	_ resource.ResourceWithConfigure   = &environmentResource{}
+	_ resource.ResourceWithImportState = &environmentResource{}
+)
+
+type envResourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	ProjectSlug types.String `tfsdk:"project_slug"`
+	Name        types.String `tfsdk:"name"`
+	Slug        types.String `tfsdk:"slug"`
+	Description types.String `tfsdk:"description"`
+	Color       types.String `tfsdk:"color"`
+}
+
+type environmentResource struct {
+	c *gqlclient.Client
+}
+
+func NewEnvironmentResource() resource.Resource {
+	return &environmentResource{}
+}
+
+func (p *environmentResource) Schema(_ context.Context, _ resource.SchemaRequest, res *resource.SchemaResponse) {
+	res.Schema = schema.Schema{
+		Description: "Project resource manages Sleuth project.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"project_slug": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The project for this environment",
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Environment name",
+				Required:            true,
+			},
+			"slug": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Environment slug",
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Environment description",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(""),
+			},
+			"color": schema.StringAttribute{
+				MarkdownDescription: "The color for the UI",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("#cecece"),
+			},
+		},
+	}
+}
+
+func (p *environmentResource) Configure(ctx context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	p.c = req.ProviderData.(*gqlclient.Client)
+}
+
+func (p *environmentResource) Metadata(ctx context.Context, req resource.MetadataRequest, res *resource.MetadataResponse) {
+	res.TypeName = req.ProviderTypeName + "_environment"
+}
+
+func (p *environmentResource) Create(ctx context.Context, req resource.CreateRequest, res *resource.CreateResponse) {
+	ctx = tflog.SetField(ctx, "resource", "environment")
+	ctx = tflog.SetField(ctx, "operation", "create")
+
+	var plan envResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	res.Diagnostics.Append(diags...)
+
+	tflog.Info(ctx, "Creating Environment resource", map[string]any{"plan": plan})
+
+	inputFields := getMutableEnvStruct(plan)
+	projectSlug := plan.ProjectSlug.ValueString()
+	envName := plan.Name.ValueString()
+	input := gqlclient.CreateEnvironmentMutationInput{ProjectSlug: projectSlug, MutableEnvironment: &inputFields}
+
+	// We create the environment automatically when Project is created, so we need to check if it already exists
+	existingEnv, err := p.c.GetEnvironmentByName(&projectSlug, &envName)
+
+	if err != nil && err != gqlclient.ErrNotFound {
+		res.Diagnostics.AddError("Error obtaining environment", fmt.Sprintf("Could not obtain environment, unexpected error: %+v", err.Error()))
+		return
+	}
+
+	var env *gqlclient.Environment
+	if existingEnv != nil {
+		input := gqlclient.UpdateEnvironmentMutationInput{ProjectSlug: projectSlug, Slug: existingEnv.Slug, MutableEnvironment: &inputFields}
+		env, err = p.c.UpdateEnvironment(input)
+		if err != nil {
+			tflog.Error(ctx, "Error updating Environment", map[string]any{"error": err.Error()})
+			res.Diagnostics.AddError(
+				"Error creating Environment",
+				fmt.Sprintf("Could not create environment, unexpected error: %+v", err.Error()),
+			)
+			return
+		}
+	} else {
+		env, err = p.c.CreateEnvironment(input)
+		if err != nil {
+			tflog.Error(ctx, "Error creating Environment", map[string]any{"error": err.Error()})
+			res.Diagnostics.AddError(
+				"Error creating Environment",
+				fmt.Sprintf("Could not create environment, unexpected error: %+v", err.Error()),
+			)
+			return
+		}
+	}
+
+	tflog.Info(ctx, "Created Environment", map[string]any{"environment": env})
+
+	state := getNewStateFromEnv(env, projectSlug)
+
+	diags = res.State.Set(ctx, state)
+	res.Diagnostics.Append(diags...)
+}
+
+func (p *environmentResource) Read(ctx context.Context, req resource.ReadRequest, res *resource.ReadResponse) {
+	ctx = tflog.SetField(ctx, "resource", "environment")
+	ctx = tflog.SetField(ctx, "operation", "read")
+
+	var state envResourceModel
+	diags := req.State.Get(ctx, &state)
+
+	tflog.Info(ctx, "Refreshing Environment resource", map[string]any{"state": fmt.Sprintf("%+v", state)})
+	res.Diagnostics.Append(diags...)
+
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	env, err := p.c.GetEnvironment(state.ProjectSlug.ValueStringPointer(), state.Slug.ValueStringPointer())
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Error obtaining environment: %+v", err))
+		res.Diagnostics.AddError(
+			"Error Reading Environment",
+			fmt.Sprintf("Could not read Environment Slug %s, %+v", state.Slug.ValueString(), err.Error()),
+		)
+		return
+	}
+	if env == nil {
+		return
+	}
+
+	newState := getNewStateFromEnv(env, state.ProjectSlug.ValueString())
+
+	diags = res.State.Set(ctx, &newState)
+	res.Diagnostics.Append(diags...)
+	return
+}
+
+func (p *environmentResource) Update(ctx context.Context, req resource.UpdateRequest, res *resource.UpdateResponse) {
+	ctx = tflog.SetField(ctx, "resource", "environment")
+	ctx = tflog.SetField(ctx, "operation", "update")
+
+	var plan envResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	res.Diagnostics.Append(diags...)
+
+	var state envResourceModel
+	diags = req.State.Get(ctx, &state)
+	res.Diagnostics.Append(diags...)
+
+	tflog.Info(ctx, "Updating Environment resource", map[string]any{"plan": plan, "state": state})
+
+	inputFields := getMutableEnvStruct(plan)
+	projectSlug := state.ProjectSlug.ValueString()
+	slug := state.Slug.ValueString()
+	input := gqlclient.UpdateEnvironmentMutationInput{
+		ProjectSlug:        projectSlug,
+		Slug:               slug,
+		MutableEnvironment: &inputFields,
+	}
+
+	env, err := p.c.UpdateEnvironment(input)
+	if err != nil {
+		diags.AddError("Error updating environment", err.Error())
+		return
+	}
+
+	tflog.Info(ctx, "Updated Environment", map[string]any{"environment": env})
+
+	newState := getNewStateFromEnv(env, projectSlug)
+
+	diags = res.State.Set(ctx, newState)
+	res.Diagnostics.Append(diags...)
+}
+
+func (p *environmentResource) Delete(ctx context.Context, req resource.DeleteRequest, res *resource.DeleteResponse) {
+	tflog.SetField(ctx, "resource", "environment")
+	tflog.SetField(ctx, "operation", "delete")
+
+	var state envResourceModel
+	req.State.Get(ctx, &state)
+
+	tflog.Info(ctx, "Deleting Environment resource", map[string]any{"state": fmt.Sprintf("%+v", state)})
+	projectSlug := state.ProjectSlug.ValueStringPointer()
+	err := p.c.DeleteEnvironment(projectSlug, state.Slug.ValueStringPointer())
+	if err != nil {
+		tflog.Error(ctx, "Unexpected error deleting environment", map[string]any{"error": err.Error()})
+		res.Diagnostics.AddError("Unexpected error deleting environment", err.Error())
+		return
+	}
+
+	res.State.RemoveResource(ctx)
+}
+
+func (p *environmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, res *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("slug"), req, res)
+}
+
+func getNewStateFromEnv(env *gqlclient.Environment, projectSlug string) envResourceModel {
+	return envResourceModel{
+		ID:          types.StringValue(env.Slug),
+		ProjectSlug: types.StringValue(projectSlug),
+		Name:        types.StringValue(env.Name),
+		Slug:        types.StringValue(env.Slug),
+		Description: types.StringValue(env.Description),
+		Color:       types.StringValue(env.Color),
+	}
+}
+
+func getMutableEnvStruct(plan envResourceModel) gqlclient.MutableEnvironment {
+	return gqlclient.MutableEnvironment{
+		Name:        plan.Name.ValueString(),
+		Description: plan.Description.ValueString(),
+		Color:       plan.Color.ValueString(),
+	}
+}

--- a/internal/sleuth/project_resource.go
+++ b/internal/sleuth/project_resource.go
@@ -157,7 +157,6 @@ func (p *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	proj, err := p.c.GetProject(state.Slug.ValueStringPointer())
-	tflog.Error(ctx, fmt.Sprintf("PRoj: %+v %+v", proj, err))
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Error obtaining project: %+v", err))
 		res.Diagnostics.AddError(

--- a/internal/sleuth/provider.go
+++ b/internal/sleuth/provider.go
@@ -48,7 +48,6 @@ func (p *sleuthProvider) Schema(_ context.Context, _ provider.SchemaRequest, res
 			"api_key": schema.StringAttribute{
 				MarkdownDescription: "The Sleuth organization's Api key",
 				Optional:            true,
-				Sensitive:           true,
 			},
 			"baseurl": schema.StringAttribute{
 				MarkdownDescription: "Ignore this, as it is only used by Sleuth developers",
@@ -132,5 +131,6 @@ func (p *sleuthProvider) Resources(_ context.Context) []func() resource.Resource
 	return []func() resource.Resource{
 		NewProjectResource,
 		NewCodeChangeSourceResource,
+		NewEnvironmentResource,
 	}
 }


### PR DESCRIPTION
Rewrite existing environment resources using Framework SDK.

Note:
this does not fix the old bug when we can't delete the default env. There is no quick fix around that so what was done was to expose data out nicer so they at least get some back telling them that something is wrong.