### PR TITLE
TIE-237 Update Metric Impact Source docs re: `integration_slug`

### DIFF
--- a/examples/resources/sleuth_metric_impact_source/resource.tf
+++ b/examples/resources/sleuth_metric_impact_source/resource.tf
@@ -12,6 +12,7 @@ resource "sleuth_metric_impact_source" "cloudwatch_rds_cpu" {
   environment_slug = "prod"
   name = "RDS CPU"
   provider_type = "cloudwatch"
+  integration_slug = "" /* If left empty or omitted completely, Sleuth will revert to `integration_slug == provider_type` */
   query = jsonencode({
     "metrics": [
       [ "AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", "my-db-identifier", { "id": "m1" } ]

--- a/internal/provider/resource_metric_impact_source.go
+++ b/internal/provider/resource_metric_impact_source.go
@@ -44,7 +44,7 @@ func resourceMetricImpactSource() *schema.Resource {
 				Required:    true,
 			},
 			"integration_slug": {
-				Description: "The integration slug",
+				Description: "Integration slug is generated automatically when an integration is set up in Sleuth. By default, it matches the `provider_type`. Any value specified in the integration's `Description label` field gets appended to the `integration_slug`, spaces replaced with dashes, e.g. `cloudwatch-test`",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},


### PR DESCRIPTION
Make it clear that if a Customer's `integration_slug` doesn't match `provider_type` value, the otherwise optional `integration_slug` must be specified.

- added the optional `integration_slug` parameter to the example block for Metric Impact Sources
- expanded the description of the `integration_slug` parameter in the schema