### PR TITLE
TIE-242:  Ignore errors when deleting default env 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.4 (unreleased)
 FIXES:
 - [#137](https://github.com/sleuth-io/terraform-provider-sleuth/pull/137) Fix code_change_source import
+- [#138](https://github.com/sleuth-io/terraform-provider-sleuth/pull/138) Fix errors when deleting default environment
 
 ## 0.4.3 (August 29, 2023)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,12 @@ When importing resources, all but the project slug are prefixed by the project s
 terraform import sleuth_environment.production PROJECT_SLUG/ENVIRONMENT_SLUG
 ```
 
+## Resources deletion caveats
+
+Due to the way Sleuth API works, there are some caveats when deleting resources. When a project resource is created, a default environment is created as well (called `Production`).
+If you want to delete the default environment, you will have to do it manually in the Sleuth UI. If you only delete environments in Terraform, the project will be left with a default environment (`Production`) even though the environment will not be present in the state.
+This can cause issues when you will try to create `code_change_source` and other resources.
+
 ## Schema
 
 ### Required

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -3,11 +3,13 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/sleuth-io/terraform-provider-sleuth/internal/gqlclient"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/sleuth-io/terraform-provider-sleuth/internal/gqlclient"
 )
 
 func resourceEnvironment() *schema.Resource {
@@ -159,7 +161,7 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 	projectSlug := parsed[0]
 	environmentSlug := parsed[1]
 
-	err := c.DeleteEnvironment(&projectSlug, &environmentSlug)
+	err := c.DeleteEnvironment(ctx, &projectSlug, &environmentSlug)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -60,6 +60,12 @@ When importing resources, all but the project slug are prefixed by the project s
 terraform import sleuth_environment.production PROJECT_SLUG/ENVIRONMENT_SLUG
 ```
 
+## Resources deletion caveats
+
+Due to the way Sleuth API works, there are some caveats when deleting resources. When a project resource is created, a default environment is created as well (called `Production`).
+If you want to delete the default environment, you will have to do it manually in the Sleuth UI. If you only delete environments in Terraform, the project will be left with a default environment (`Production`) even though the environment will not be present in the state.
+This can cause issues when you will try to create `code_change_source` and other resources.
+
 ## Schema
 
 ### Required


### PR DESCRIPTION
When we try to delete default env, we will get back the `Missing` error. Given that most time when deleting env, we will also delete project, we will swallow err for the time being and just remove env from the state.

To test:
- create a project and track a default `Production` environment
- delete an environment and project from the `main.tf`


```terraform
resource "sleuth_project" "terraform_test_deletion" {
   name = "Terraform env testing deletion"
   build_provider = "GITHUB"
}

resource "sleuth_environment" "prod_deletion" {
  project_slug = sleuth_project.terraform_test_deletion.slug
  name = "Production"
  color = "#279694"
}
```

Results:
- before - error is returned
- after - successfully deleted


Resolves: https://github.com/sleuth-io/terraform-provider-sleuth/issues/136