### PR TITLE
TIE-262: Update docs to clarify expected values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5
+EHANCEMENTS:
+- [#140](https://github.com/sleuth-io/terraform-provider-sleuth/pull/140) Update OpsGenie Incident Impact Source docs
+
 ## 0.4.4 (September 25, 2023)
 FIXES:
 - [#137](https://github.com/sleuth-io/terraform-provider-sleuth/pull/137) Fix code_change_source import

--- a/docs/resources/incident_impact_source.md
+++ b/docs/resources/incident_impact_source.md
@@ -175,7 +175,7 @@ Optional:
 - `remote_alert_tags` (String) Optionally filter by alert tags
 - `remote_incident_tags` (String) Optionally filter by incident tags
 - `remote_priority_threshold` (String) Monitor states with matching or higher priorities will be considered a failure in Sleuth
-- `remote_service` (String) Only taken into consideration when using OpsGenie Incidents
+- `remote_service` (String) Only taken into consideration when using OpsGenie Incidents. This value should be the Unique ID of the OpsGenie service.
 - `remote_use_alerts` (Boolean) Use OpsGenie Alerts instead of Incidents
 
 

--- a/internal/provider/resource_incident_impact_source.go
+++ b/internal/provider/resource_incident_impact_source.go
@@ -275,7 +275,7 @@ Options: ALL, P1, P2, P3, P4, P5. Defaults to ALL`,
 						"remote_service": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Only taken into consideration when using OpsGenie Incidents",
+							Description: "Only taken into consideration when using OpsGenie Incidents. This value should be the Unique ID of the OpsGenie service.",
 						},
 						"remote_use_alerts": {
 							Type:        schema.TypeBool,


### PR DESCRIPTION
Users were confused about what `remote_service` needed. They were supplying a service name, but it actually needs a service ID. This updates the docs to clarify that.