### PR TITLE
TIE-274: Change provider value from API to uppercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6 (unreleased)
+FIXES:
+[#142](https://github.com/sleuth-io/terraform-provider-sleuth/pull/142) Fix provider value case from API
+
 ## 0.4.5 (September 26, 2023)
 EHANCEMENTS:
 - [#140](https://github.com/sleuth-io/terraform-provider-sleuth/pull/140) Update OpsGenie Incident Impact Source docs

--- a/internal/gqlclient/change_sources.go
+++ b/internal/gqlclient/change_sources.go
@@ -2,6 +2,7 @@ package gqlclient
 
 import (
 	"errors"
+
 	"github.com/shurcooL/graphql"
 )
 

--- a/internal/gqlclient/code_change_sources.go
+++ b/internal/gqlclient/code_change_sources.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/shurcooL/graphql"
 	"strings"
+
+	"github.com/shurcooL/graphql"
 )
 
 func (c *Client) GetCodeChangeSource(ctx context.Context, projectSlug *string, slug *string) (*CodeChangeSource, error) {
@@ -31,15 +32,14 @@ func (c *Client) GetCodeChangeSource(ctx context.Context, projectSlug *string, s
 		if src.Type == "CODE" {
 			if src.ChangeSource.Slug == *slug {
 				src.ChangeSource.Repository.Provider = strings.ToUpper(src.ChangeSource.Repository.Provider)
-				for idx, _ := range src.ChangeSource.DeployTrackingBuildMappings {
-					src.ChangeSource.DeployTrackingBuildMappings[idx].Provider = strings.ToLower(src.ChangeSource.DeployTrackingBuildMappings[idx].Provider)
+				// TODO: this should not be done here but we want to be consistent for now
+				for idx, buildMapping := range src.ChangeSource.DeployTrackingBuildMappings {
+					src.ChangeSource.DeployTrackingBuildMappings[idx].Provider = strings.ToUpper(buildMapping.Provider)
 				}
 				return &src.ChangeSource, nil
 			}
-
 		}
 	}
-
 	return nil, nil
 }
 


### PR DESCRIPTION
Currently repository & build provider is not uppercase when it is returned from the API but we expect it to be - fix it