### PR TITLE
WIP-324: Add .devcontainer config file for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/universal:2",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/terraform-asdf:2": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go"
+			]
+		}
+	}
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.7 (unreleased)
+EHANCEMENTS:
+[#147](https://github.com/sleuth-io/terraform-provider-sleuth/pull/147) Add .devcontainer config file for GitHub Codespaces
+
 ## 0.4.6 (October 23, 2023)
 FIXES:
 [#142](https://github.com/sleuth-io/terraform-provider-sleuth/pull/142) Fix provider value case from API

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -5,7 +5,6 @@ Either:
 - [Devbox](https://www.jetpack.io/devbox/docs/installing_devbox/) for dependencies and development
 - install dependencies manually, see [Requirements](../../README.md).
 - GitHub's Codespaces which comes with `go` preinstalled out of the box
-    - you'll need to install Terraform via `sudo apt update && sudo apt install terraform` and run tunnel to your Django (dev.sleuth.io) server locally
     - to run in Codespaces open this repo on GitHub, find green `<> Code` dropdown button and select `Codespaces` tab
 
 ## Getting dependencies

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -29,6 +29,9 @@ resource "sleuth_project" "example_tf_app" {
 
 - `build_provider` (String) Where to find builds related to changes
 - `change_failure_rate_boundary` (String) The health rating at which point it will be considered a failure
+- `change_lead_time_issue_states` (Set of Number) Issue state IDs used for start definition (only used if change_lead_time_start_definition is ISSUE or FIRST_EVENT.
+- `change_lead_time_start_definition` (String) The event that will be taken as a start definition (first commit, issue transition or whichever comes first) - options: COMMIT (default), ISSUE, FIRST_EVENT.
+- `change_lead_time_strict_matching` (Boolean) When enabled Sleuth will only look for issue references in PR titles and PR branch names. If strict issue matching is disabled, Sleuth will expand the search for issue references to PR descriptions and commit messages.
 - `description` (String, Deprecated) Project description
 - `failure_sensitivity` (Number) The amount of time (in seconds) a deploy must spend in a failure status (Unhealthy, Incident, etc.) before it is determined a failure. Setting this value to a longer time means that less deploys will be classified.
 - `impact_sensitivity` (String) How many impact measures Sleuth takes into account when auto-determining a deploys health.

--- a/templates/contributing/README.md.tmpl
+++ b/templates/contributing/README.md.tmpl
@@ -5,7 +5,6 @@ Either:
 - [Devbox](https://www.jetpack.io/devbox/docs/installing_devbox/) for dependencies and development
 - install dependencies manually, see [Requirements](../../README.md).
 - GitHub's Codespaces which comes with `go` preinstalled out of the box
-    - you'll need to install Terraform via `sudo apt update && sudo apt install terraform` and run tunnel to your Django (dev.sleuth.io) server locally
     - to run in Codespaces open this repo on GitHub, find green `<> Code` dropdown button and select `Codespaces` tab
 
 ## Getting dependencies


### PR DESCRIPTION
Aka `devcontainer.json` file so everyone else will get machine with
`go` and `terraform` preinstalled.

About 2 weeks ago, you could simply get terraform via `sudo apt update && sudo apt install terraform`, but now you can't anymore.

Now you need to follow many steps as described on [terraform docs](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli), so I decided to add this `devcontainer` config instead.