### PR TITLE
BROC-1198: Prepare v0.4.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## unreleased
+## 0.4.8 (May 17, 2024)
 ENHANCEMENTS:
 - [#165](https://github.com/sleuth-io/terraform-provider-sleuth/pull/165) Fix provider name in main.go
 


### PR DESCRIPTION
Last v0.4 release until new 0.5 version is released.