### PR TITLE
SD-8511: TF provider crashes when creating a code deployment

### DIFF
--- a/internal/sleuth/code_change_source_resource.go
+++ b/internal/sleuth/code_change_source_resource.go
@@ -270,6 +270,7 @@ func (ccsr *codeChangeSourceResource) Create(ctx context.Context, req resource.C
 	inputFields, err := getMutableCodeChangeSourceStruct(plan)
 	if err != nil {
 		res.Diagnostics.AddError("Could not create input object", fmt.Sprintf("Could not create input object: %+v", err.Error()))
+		return
 	}
 
 	input := gqlclient.CreateCodeChangeSourceMutationInput{
@@ -362,6 +363,7 @@ func (ccsr *codeChangeSourceResource) Update(ctx context.Context, req resource.U
 	inputFields, err := getMutableCodeChangeSourceStruct(plan)
 	if err != nil {
 		res.Diagnostics.AddError("Could not create input object", fmt.Sprintf("Could not create input object: %+v", err.Error()))
+		return
 	}
 
 	input := gqlclient.UpdateCodeChangeSourceMutationInput{
@@ -528,7 +530,7 @@ func getMutableCodeChangeSourceStruct(plan codeChangeResourceModel) (*gqlclient.
 		environmentSlug := bm.EnvironmentSlug.ValueString()
 		buildBranch, ok := environmentMappingsLookup[environmentSlug]
 		if !ok {
-			return nil, fmt.Errorf("could not find branch for build mapping for environment slug: %s", environmentSlug)
+			return nil, fmt.Errorf("could not find branch for build mapping for environment slug: %s. Did you forget to include this or all environments in the `environment_mappings` field?", environmentSlug)
 		}
 		buildMappingsT = append(buildMappingsT, gqlclient.BuildMapping{
 			EnvironmentSlug:          environmentSlug,

--- a/internal/sleuth/code_change_source_resource.go
+++ b/internal/sleuth/code_change_source_resource.go
@@ -290,7 +290,7 @@ func (ccsr *codeChangeSourceResource) Create(ctx context.Context, req resource.C
 		tflog.Error(ctx, "Error creating CodeChangeSource", map[string]any{"error": err.Error()})
 		res.Diagnostics.AddError(
 			"Error creating CodeChangeSource",
-			fmt.Sprintf("Could not create code change soure, unexpected error: %+v", err.Error()),
+			fmt.Sprintf("Could not create code change source, unexpected error: %+v", err.Error()),
 		)
 		return
 	}
@@ -326,7 +326,7 @@ func (ccsr *codeChangeSourceResource) Read(ctx context.Context, req resource.Rea
 		tflog.Error(ctx, "Error reading CodeChangeSource", map[string]any{"error": err.Error()})
 		res.Diagnostics.AddError(
 			"Error reading CodeChangeSource",
-			fmt.Sprintf("Could not read code change soure, unexpected error: %+v", err.Error()),
+			fmt.Sprintf("Could not read code change source, unexpected error: %+v", err.Error()),
 		)
 		return
 	}

--- a/main.tf.example
+++ b/main.tf.example
@@ -43,11 +43,11 @@ resource "sleuth_code_change_source" "cd" {
   }
   environment_mappings = [
       {
-        environment_slug = sleuth_environment.staging.slug
+        environment_slug = sleuth_environment.prod.slug
         branch = "main"
       },
       {
-        environment_slug = sleuth_environment.prod.slug
+        environment_slug = sleuth_environment.staging.slug
         branch = "main"
       }
   ]
@@ -77,7 +77,7 @@ resource "sleuth_incident_impact_source" "pd" {
     name = "PagerDuty TF incident impact"
     environment_name = sleuth_environment.staging.name
     provider_name = "PAGERDUTY"
-    pagerduty_input {
+    pagerduty_input = {
         remote_services = ""
         remote_urgency = "ANY"
     }


### PR DESCRIPTION
Two minor unrelated fixes, the actual fix is all in the `internal/sleuth/code_change_source_resource.go` file change.