### PR TITLE
FEA-330: Add support setting labels on project creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3 (Oct 04, 2024)
+ENHANCEMENTS:
+- [#201](https://github.com/sleuth-io/terraform-provider-sleuth/pull/201) Add support setting labels on project creation
+
 ## 0.6.2 (Sep 26, 2024)
 ENHANCEMENTS:
 - [#198](https://github.com/sleuth-io/terraform-provider-sleuth/issues/198) Add support for Rootly

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -36,6 +36,7 @@ resource "sleuth_project" "example_tf_app" {
 - `failure_sensitivity` (Number) The amount of time (in seconds) a deploy must spend in a failure status (Unhealthy, Incident, etc.) before it is determined a failure. Setting this value to a longer time means that less deploys will be classified.
 - `impact_sensitivity` (String) How many impact measures Sleuth takes into account when auto-determining a deploys health.
 - `issue_tracker_provider_type` (String) Where to find issues linked to by changes
+- `labels` (List of String) Labels are used to categorize projects.
 
 ### Read-Only
 

--- a/internal/gqlclient/models.go
+++ b/internal/gqlclient/models.go
@@ -16,6 +16,7 @@ type Project struct {
 	CltStartDefinition        string           `json:"cltStartDefinition,omitempty"`
 	CltStartStates            []CLTStartStates `json:"cltStartStates,omitempty"`
 	StrictIssueMatching       bool             `json:"strictIssueMatching,omitempty"`
+	LabelNames                []string         `json:"labelNames"`
 }
 
 type Environment struct {
@@ -91,16 +92,17 @@ type CodeChangeSource struct {
 }
 
 type MutableProject struct {
-	Name                      string `json:"name"`
-	Description               string `json:"description,omitempty"`
-	IssueTrackerProvider      string `json:"issueTrackerProvider,omitempty"`
-	BuildProvider             string `json:"buildProvider,omitempty"`
-	ChangeFailureRateBoundary string `json:"changeFailureRateBoundary,omitempty"`
-	ImpactSensitivity         string `json:"impactSensitivity,omitempty"`
-	FailureSensitivity        int    `json:"failureSensitivity,omitempty"`
-	CltStartDefinition        string `json:"cltStartDefinition,omitempty"`
-	CltStartStates            []int  `json:"cltStartStates,omitempty"`
-	StrictIssueMatching       bool   `json:"strictIssueMatching,omitempty"`
+	Name                      string   `json:"name"`
+	Description               string   `json:"description,omitempty"`
+	IssueTrackerProvider      string   `json:"issueTrackerProvider,omitempty"`
+	BuildProvider             string   `json:"buildProvider,omitempty"`
+	ChangeFailureRateBoundary string   `json:"changeFailureRateBoundary,omitempty"`
+	ImpactSensitivity         string   `json:"impactSensitivity,omitempty"`
+	FailureSensitivity        int      `json:"failureSensitivity,omitempty"`
+	CltStartDefinition        string   `json:"cltStartDefinition,omitempty"`
+	CltStartStates            []int    `json:"cltStartStates,omitempty"`
+	StrictIssueMatching       bool     `json:"strictIssueMatching,omitempty"`
+	Labels                    []string `json:"labels"`
 }
 
 type CreateProjectMutationInput struct {

--- a/internal/sleuth/project_resource.go
+++ b/internal/sleuth/project_resource.go
@@ -130,6 +130,7 @@ func (p *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description: "Labels are used to categorize projects.",
 				ElementType: basetypes.StringType{},
 				Optional:    true,
+				Computed:    true,
 			},
 		},
 	}
@@ -307,13 +308,10 @@ func getNewStateFromProject(ctx context.Context, proj *gqlclient.Project) (proje
 		ChangeLeadTimeStartDefinition: types.StringValue(proj.CltStartDefinition),
 		ChangeLeadTimeIssueStates:     types.SetNull(types.Int64Type),
 		ChangeLeadTimeStrictMatching:  types.BoolValue(proj.StrictIssueMatching),
-		Labels:                        types.ListNull(types.StringType),
+		Labels:                        labelsValue,
 	}
 	if len(proj.CltStartStates) > 0 {
 		prm.ChangeLeadTimeIssueStates = setValue
-	}
-	if len(proj.LabelNames) > 0 {
-		prm.Labels = labelsValue
 	}
 
 	return prm, errDiag

--- a/internal/sleuth/project_resource.go
+++ b/internal/sleuth/project_resource.go
@@ -41,6 +41,7 @@ type projectResourceModel struct {
 	ChangeLeadTimeStartDefinition types.String `tfsdk:"change_lead_time_start_definition"`
 	ChangeLeadTimeIssueStates     types.Set    `tfsdk:"change_lead_time_issue_states"`
 	ChangeLeadTimeStrictMatching  types.Bool   `tfsdk:"change_lead_time_strict_matching"`
+	Labels                        types.List   `tfsdk:"labels"`
 }
 
 type projectResource struct {
@@ -124,6 +125,11 @@ func (p *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
+			},
+			"labels": schema.ListAttribute{
+				Description: "Labels are used to categorize projects.",
+				ElementType: basetypes.StringType{},
+				Optional:    true,
 			},
 		},
 	}
@@ -282,6 +288,12 @@ func getNewStateFromProject(ctx context.Context, proj *gqlclient.Project) (proje
 
 	setValue, errDiag := types.SetValue(basetypes.Int64Type{}, cltStateInts)
 
+	var labels []attr.Value
+	for _, label := range proj.LabelNames {
+		labels = append(labels, types.StringValue(label))
+	}
+	labelsValue, _ := types.ListValue(basetypes.StringType{}, labels)
+
 	prm := projectResourceModel{
 		ID:                            types.StringValue(proj.Slug),
 		Name:                          types.StringValue(proj.Name),
@@ -295,9 +307,13 @@ func getNewStateFromProject(ctx context.Context, proj *gqlclient.Project) (proje
 		ChangeLeadTimeStartDefinition: types.StringValue(proj.CltStartDefinition),
 		ChangeLeadTimeIssueStates:     types.SetNull(types.Int64Type),
 		ChangeLeadTimeStrictMatching:  types.BoolValue(proj.StrictIssueMatching),
+		Labels:                        types.ListNull(types.StringType),
 	}
 	if len(proj.CltStartStates) > 0 {
 		prm.ChangeLeadTimeIssueStates = setValue
+	}
+	if len(proj.LabelNames) > 0 {
+		prm.Labels = labelsValue
 	}
 
 	return prm, errDiag
@@ -306,6 +322,8 @@ func getNewStateFromProject(ctx context.Context, proj *gqlclient.Project) (proje
 func getMutableProjectStruct(ctx context.Context, plan projectResourceModel) gqlclient.MutableProject {
 	var cltStartStates []int
 	plan.ChangeLeadTimeIssueStates.ElementsAs(ctx, &cltStartStates, false)
+	var labels []string
+	plan.Labels.ElementsAs(ctx, &labels, false)
 
 	return gqlclient.MutableProject{
 		Name:                      plan.Name.ValueString(),
@@ -318,5 +336,6 @@ func getMutableProjectStruct(ctx context.Context, plan projectResourceModel) gql
 		CltStartDefinition:        plan.ChangeLeadTimeStartDefinition.ValueString(),
 		CltStartStates:            cltStartStates,
 		StrictIssueMatching:       plan.ChangeLeadTimeStrictMatching.ValueBool(),
+		Labels:                    labels,
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/sleuth-io/sleuth/pull/10415

Allows you to specify project labels like so:

```tf
resource "sleuth_project" "terraform_poc" {
  name = "Testing"
  labels = ["terraform", "testing"]
}
```

I think acceptance tests are failing because we didn't deploy https://github.com/sleuth-io/sleuth/pull/10415 yet to prod or staging. I tried to run `make testacc` locally as described in https://github.com/sleuth-io/terraform-provider-sleuth/blob/ziga/fea-330-support-managing-project-labels-in-terraform/docs/contributing/README.md#testing but it errors out for me with

```
Error: API key must be set
```

but I have no idea where to set it since it's not documented :/