### PR TITLE
SD-8520: remove cached int_slug for repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.5 (Oct 11, 2024)
 ENHANCEMENTS:
-- [#204](https://github.com/sleuth-io/terraform-provider-sleuth/pull/204)
+- [#206](https://github.com/sleuth-io/terraform-provider-sleuth/pull/206)
   - No longer using cached state value for repository.integration_slug
 
 ## 0.6.4 (Oct 09, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.5 (Oct 11, 2024)
+ENHANCEMENTS:
+- [#204](https://github.com/sleuth-io/terraform-provider-sleuth/pull/204)
+  - No longer using cached state value for repository.integration_slug
+
 ## 0.6.4 (Oct 09, 2024)
 ENHANCEMENTS:
 - [#203](https://github.com/sleuth-io/terraform-provider-sleuth/pull/203) Improved error and null handling

--- a/internal/sleuth/code_change_source_resource.go
+++ b/internal/sleuth/code_change_source_resource.go
@@ -159,9 +159,6 @@ func (ccsr *codeChangeSourceResource) Schema(_ context.Context, _ resource.Schem
 						MarkdownDescription: "IntegrationAuthentication slug used",
 						Optional:            true,
 						Computed:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"repo_uid": schema.StringAttribute{
 						MarkdownDescription: "Repository UID, required only for AZURE provider. You can obtain data from [API](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/repositories/list?view=azure-devops-rest-6.0&tabs=HTTP)",


### PR DESCRIPTION
It seems the repository.integration_slug causes errors if it's populated by a variable and used for multiple jobs.

This error does not happen on the build_mappings which use the same value. This PR just removes the state caching on the repo value to make it behave like the build mapping value