### PR TITLE
SD-8567: Add timeout field to provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,3 +76,7 @@ This can cause issues when you will try to create `code_change_source` and other
 ### Required
 
 - **api_key** (String) The Sleuth organization's Api key
+
+### Optional
+
+- **timeout** (Integer) Timeout for Sleuth API calls in seconds

--- a/internal/gqlclient/client.go
+++ b/internal/gqlclient/client.go
@@ -5,7 +5,6 @@ import (
 	// 	"encoding/json"
 	"fmt"
 	"net/http"
-
 	// 	"strings"
 	"time"
 
@@ -34,8 +33,8 @@ func (transport *AuthenticatedTransport) RoundTrip(req *http.Request) (*http.Res
 }
 
 // NewClient -
-func NewClient(baseurl, apiKey *string, ua string) (*Client, error) {
-	httpClient := http.Client{Timeout: 20 * time.Second,
+func NewClient(baseurl, apiKey *string, ua string, timeout time.Duration) (*Client, error) {
+	httpClient := http.Client{Timeout: timeout,
 		Transport: &AuthenticatedTransport{http.DefaultTransport, *apiKey, ua}}
 	c := Client{
 		GQLClient:  graphql.NewClient(*baseurl+"/graphql", &httpClient),

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -76,3 +76,7 @@ This can cause issues when you will try to create `code_change_source` and other
 ### Required
 
 - **api_key** (String) The Sleuth organization's Api key
+
+### Optional
+
+- **timeout** (Integer) Timeout for Sleuth API calls in seconds


### PR DESCRIPTION
The default timeout of 20 seconds appears to be insufficient in some cases (I encounter timeouts 100% of the time when applying impact source changes or creations). Making this configurable allows for accounting for these cases, and cases where users have slow or high-latency internet connections.