### PR TITLE
SD-8531: Expose repository webhook as computed attribute

### DIFF
--- a/internal/gqlclient/models.go
+++ b/internal/gqlclient/models.go
@@ -61,6 +61,12 @@ type RepositoryBase struct {
 type Repository struct {
 	RepositoryBase
 	IntegrationAuth *IntegrationAuth `json:"integrationAuth,omitempty"`
+	Webhook         *Webhook         `json:"webhook,omitempty"`
+}
+
+type Webhook struct {
+	Url    string `json:"url"`
+	Secret string `json:"secret,omitempty"`
 }
 
 type IntegrationAuth struct {

--- a/internal/sleuth/code_change_source_resource.go
+++ b/internal/sleuth/code_change_source_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -45,19 +46,26 @@ type codeChangeResourceModel struct {
 }
 
 type repositoryResourceModel struct {
-	Owner           types.String          `tfsdk:"owner"`
-	Name            types.String          `tfsdk:"name"`
-	URL             types.String          `tfsdk:"url"`
-	Provider        types.String          `tfsdk:"provider"`
-	IntegrationSlug types.String          `tfsdk:"integration_slug"`
-	RepoUID         types.String          `tfsdk:"repo_uid"`
-	ProjectUID      types.String          `tfsdk:"project_uid"`
-	Webhook         *webhookResourceModel `tfsdk:"webhook"`
+	Owner           types.String `tfsdk:"owner"`
+	Name            types.String `tfsdk:"name"`
+	URL             types.String `tfsdk:"url"`
+	Provider        types.String `tfsdk:"provider"`
+	IntegrationSlug types.String `tfsdk:"integration_slug"`
+	RepoUID         types.String `tfsdk:"repo_uid"`
+	ProjectUID      types.String `tfsdk:"project_uid"`
+	Webhook         types.Object `tfsdk:"webhook"`
 }
 
 type webhookResourceModel struct {
 	URL    types.String `tfsdk:"url"`
 	Secret types.String `tfsdk:"secret"`
+}
+
+func (w webhookResourceModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"url":    types.StringType,
+		"secret": types.StringType,
+	}
 }
 
 type environmentMappingsResourceModel struct {
@@ -525,7 +533,7 @@ func getNewStateFromCodeChangeSource(ctx context.Context, ccs *gqlclient.CodeCha
 		IntegrationSlug: types.StringNull(),
 		RepoUID:         types.StringNull(),
 		ProjectUID:      types.StringNull(),
-		Webhook:         nil,
+		Webhook:         types.ObjectNull(webhookResourceModel{}.AttributeTypes()),
 	}
 
 	if ccs.Repository.IntegrationAuth != nil {
@@ -533,10 +541,14 @@ func getNewStateFromCodeChangeSource(ctx context.Context, ccs *gqlclient.CodeCha
 	}
 
 	if ccs.Repository.Webhook != nil {
-		r.Webhook = &webhookResourceModel{
+		webhook := webhookResourceModel{
 			URL:    types.StringValue(ccs.Repository.Webhook.Url),
 			Secret: types.StringValue(ccs.Repository.Webhook.Secret),
 		}
+
+		var webhookDiags diag.Diagnostics
+		r.Webhook, webhookDiags = types.ObjectValueFrom(ctx, webhook.AttributeTypes(), webhook)
+		diags.Append(webhookDiags...)
 	}
 
 	if strings.ToLower(ccs.Repository.Provider) == azureProvider {


### PR DESCRIPTION
Resolves #200

When code integrations are configured in Sleuth in read-only mode, it is up to the user to manually add the relevant webhook to the relevant repository. These webhooks require secret tokens, which are only available in Sleuth after the code change source has been created.

This change allows a user of the Terraform provider to automatically create the webhooks in their code integration source. For example, with GitLab, it is possible to do:

```terraform

  resource "sleuth_code_change_source" "example" {
    # [...]
  }

  resource "gitlab_project_hook" "example" {
    project = "${sleuth_code_change_source.example.repository.owner}/${sleuth_code_change_source.example.repository.name}"
    url     = sleuth_code_change_source.example.repository.webhook.url
    token   = sleuth_code_change_source.example.repository.webhook.secret

    job_events            = true
    merge_requests_events = true
    push_events           = true
    tag_push_events       = true
  }

```