### PR TITLE
SD-8574: Add support for `isCustom` attribute on build mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.8 (Mar 10, 2025)
+ENHANCEMENTS:
+- [#234](https://github.com/sleuth-io/terraform-provider-sleuth/pull/234)
+  - Add support for isCustom attribute on build mappings
+
 ## 0.6.7 (Jan 10, 2025)
 ENHANCEMENTS:
 - [#219](https://github.com/sleuth-io/terraform-provider-sleuth/pull/219)

--- a/docs/resources/code_change_source.md
+++ b/docs/resources/code_change_source.md
@@ -108,7 +108,7 @@ Required:
 Optional:
 
 - `integration_slug` (String) IntegrationAuthentication slug used
-- `is_custom` (Boolean) Whether this is a custom build name mapping or not. This needs to be set to true if a build or job or build name isn't visible in Sleuth. Defaults to false
+- `is_custom` (Boolean) Whether this is a custom build mapping or not. This needs to be set to true if a build name or job name isn't visible in Sleuth. Defaults to false
 - `job_name` (String) The job or stage within the build or pipeline, if supported
 - `match_branch_to_environment` (Boolean) Whether only builds performed on the branch mapped from the environment are tracked or not. Basically if you only want Sleuth to find builds that were triggeredby a change on the branch that is configured for the environment, set this to false. Defaults to true
 - `project_key` (String) The build project key

--- a/docs/resources/code_change_source.md
+++ b/docs/resources/code_change_source.md
@@ -108,6 +108,7 @@ Required:
 Optional:
 
 - `integration_slug` (String) IntegrationAuthentication slug used
+- `is_custom` (Boolean) Whether this is a custom build name mapping or not. This needs to be set to true if a build or job or build name isn't visible in Sleuth. Defaults to false
 - `job_name` (String) The job or stage within the build or pipeline, if supported
 - `match_branch_to_environment` (Boolean) Whether only builds performed on the branch mapped from the environment are tracked or not. Basically if you only want Sleuth to find builds that were triggeredby a change on the branch that is configured for the environment, set this to false. Defaults to true
 - `project_key` (String) The build project key

--- a/internal/gqlclient/models.go
+++ b/internal/gqlclient/models.go
@@ -204,6 +204,7 @@ type BuildMapping struct {
 	IntegrationSlug          string `json:"integrationSlug"`
 	BuildBranch              string `json:"buildBranch"`
 	MatchBranchToEnvironment bool   `json:"matchBranchToEnvironment,omitempty"`
+	IsCustom                 bool   `json:"isCustom,omitempty"`
 }
 
 // This represents the build mapping as retrieved from a query
@@ -215,6 +216,7 @@ type DeployTrackingBuildMapping struct {
 	JobName                  string      `json:"jobName,omitempty"`
 	BuildProjectKey          string      `json:"buildProjectKey"`
 	MatchBranchToEnvironment bool        `json:"matchBranchToEnvironment"`
+	IsCustom                 bool        `json:"isCustom"`
 }
 
 type MutableCodeChangeSource struct {

--- a/internal/sleuth/code_change_source_resource.go
+++ b/internal/sleuth/code_change_source_resource.go
@@ -260,8 +260,8 @@ func (ccsr *codeChangeSourceResource) Schema(_ context.Context, _ resource.Schem
 							Default:  booldefault.StaticBool(true),
 						},
 						"is_custom": schema.BoolAttribute{
-							MarkdownDescription: "Whether this is a custom build name mapping or not. This needs to be set to true if a build or job or build " +
-								"name isn't visible in Sleuth. Defaults to false",
+							MarkdownDescription: "Whether this is a custom build mapping or not. This needs to be set to true " +
+								"if a build name or job name isn't visible in Sleuth. Defaults to false",
 							Optional: true,
 							Computed: true,
 							Default:  booldefault.StaticBool(false),

--- a/internal/sleuth/code_change_source_resource.go
+++ b/internal/sleuth/code_change_source_resource.go
@@ -82,6 +82,7 @@ type buildMappingsResourceModel struct {
 	JobName                  types.String `tfsdk:"job_name"`
 	ProjectKey               types.String `tfsdk:"project_key"`
 	MatchBranchToEnvironment types.Bool   `tfsdk:"match_branch_to_environment"`
+	IsCustom                 types.Bool   `tfsdk:"is_custom"`
 }
 
 const azureProvider = "azure"
@@ -257,6 +258,13 @@ func (ccsr *codeChangeSourceResource) Schema(_ context.Context, _ resource.Schem
 							Optional: true,
 							Computed: true,
 							Default:  booldefault.StaticBool(true),
+						},
+						"is_custom": schema.BoolAttribute{
+							MarkdownDescription: "Whether this is a custom build name mapping or not. This needs to be set to true if a build or job or build " +
+								"name isn't visible in Sleuth. Defaults to false",
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
 						},
 					},
 				},
@@ -505,6 +513,7 @@ func getNewStateFromCodeChangeSource(ctx context.Context, ccs *gqlclient.CodeCha
 			JobName:                  types.StringValue(bm.JobName),
 			ProjectKey:               types.StringValue(bm.BuildProjectKey),
 			MatchBranchToEnvironment: types.BoolValue(bm.MatchBranchToEnvironment),
+			IsCustom:                 types.BoolValue(bm.IsCustom),
 		}
 
 		if bm.IntegrationSlug == "" {
@@ -602,6 +611,7 @@ func getMutableCodeChangeSourceStruct(plan codeChangeResourceModel) (*gqlclient.
 			IntegrationSlug:          bm.IntegrationSlug.ValueString(),
 			BuildBranch:              buildBranch,
 			MatchBranchToEnvironment: bm.MatchBranchToEnvironment.ValueBool(),
+			IsCustom:                 bm.IsCustom.ValueBool(),
 		})
 	}
 


### PR DESCRIPTION
https://linear.app/sleuth/issue/SD-8574/allow-marking-build-mappings-as-custom-via-tf-provider