### PR TITLE
SD-8790: Fix panic when code deployment doesn't exist

### DIFF
--- a/internal/gqlclient/code_change_sources.go
+++ b/internal/gqlclient/code_change_sources.go
@@ -9,6 +9,10 @@ import (
 	"github.com/shurcooL/graphql"
 )
 
+// ErrNoCodeChangeSourceFound indicates that a code change source with the given
+// project slug & slug does not exist.
+var ErrNoCodeChangeSourceFound = errors.New("code change source not found")
+
 func (c *Client) GetCodeChangeSource(ctx context.Context, projectSlug *string, slug *string) (*CodeChangeSource, error) {
 	var query struct {
 		Project struct {
@@ -40,7 +44,7 @@ func (c *Client) GetCodeChangeSource(ctx context.Context, projectSlug *string, s
 			}
 		}
 	}
-	return nil, nil
+	return nil, ErrNoCodeChangeSourceFound
 }
 
 func (c *Client) CreateCodeChangeSource(input CreateCodeChangeSourceMutationInput) (*CodeChangeSource, error) {


### PR DESCRIPTION
When a code change source managed by Terraform and tracked in Terraform state is deleted externally (e.g. by manually deleting it in the interface), the Terraform provider currently panics upon trying to apply without any Terraform changes:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0xab6e8b]

goroutine 2099 [running]:
github.com/sleuth-io/terraform-provider-sleuth/internal/sleuth.getNewStateFromCodeChangeSource({_, _}, _, {_, _}, {{0x2, {0xc001889900, 0x9}}, {0x2, {0xc0012b6a50, ...}}, ...})
        github.com/sleuth-io/terraform-provider-sleuth/internal/sleuth/code_change_source_resource.go:497 +0x8b
github.com/sleuth-io/terraform-provider-sleuth/internal/sleuth.(*codeChangeSourceResource).Read(0xc00007e5d0, {0xdb2448?, 0xc001523680?}, {{{{0xdb7070, 0xc0018a2cc0}, {0xb7b4c0, 0xc0018a24e0}}, {0xdb9128, 0xc000d9da40}}, 0xc00007e5e8, ...}, ...)
        github.com/sleuth-io/terraform-provider-sleuth/internal/sleuth/code_change_source_resource.go:385 +0x791
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ReadResource(0xc0001eb448, {0xdb2448, 0xc001523680}, 0xc001523710, 0xc0018c1618)                                                                                                                                    github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/server_readresource.go:117 +0x86e
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ReadResource(0xc0001eb448, {0xdb2448?, 0xc001523530?}, 0xc001371bc0)
        github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/proto6server/server_readresource.go:55 +0x38e
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ReadResource(0xc000250820, {0xdb2448?, 0xc001522d80?}, 0xc0015f3340)
        github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/tf6server/server.go:784 +0x309
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ReadResource_Handler({0xc636e0, 0xc000250820}, {0xdb2448, 0xc001522d80}, 0xc001426e80, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:575 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00020ce00, {0xdb2448, 0xc001522cf0}, {0xdb7f00, 0xc0001d9a00}, 0xc0015add40, 0xc0002dfe90, 0x12d1dc8, 0x0)
        google.golang.org/grpc@v1.67.1/server.go:1394 +0xe49
google.golang.org/grpc.(*Server).handleStream(0xc00020ce00, {0xdb7f00, 0xc0001d9a00}, 0xc0015add40)
        google.golang.org/grpc@v1.67.1/server.go:1805 +0xe8b
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.67.1/server.go:1029 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 25
        google.golang.org/grpc@v1.67.1/server.go:1040 +0x125

Error: The terraform-provider-sleuth_v0.6.8 plugin crashed!
```

This is because the `nil` return value in GetCodeChangeSource is never checked: it is assumed that a nil error means a non-nil CodeChangeSource pointer, which is a generally reasonable assumption to make in idiomatic Go code [1].

Thus, this commit introduces a new error, and returns it when the code change source cannot be found. This error is already being checked in the one place that GetCodeChangeSource is invoked, and hence this change results in a friendly, non-fatal error to the user, rather than a runtime panic on a nil pointer dereference.

[1]: https://github.com/Antonboom/nilnil